### PR TITLE
Durability bufferpool

### DIFF
--- a/benchmark/record_manager_concurrency_test.cpp
+++ b/benchmark/record_manager_concurrency_test.cpp
@@ -23,6 +23,7 @@ See the Mulan PSL v2 for more details. */
 #include "storage/common/condition_filter.h"
 #include "storage/record/record_manager.h"
 #include "storage/trx/vacuous_trx.h"
+#include "storage/clog/vacuous_log_handler.h"
 
 using namespace std;
 using namespace common;
@@ -99,7 +100,7 @@ public:
       throw runtime_error("failed to create record buffer pool file.");
     }
 
-    rc = bpm.open_file(record_filename.c_str(), buffer_pool_);
+    rc = bpm.open_file(log_handler_, record_filename.c_str(), buffer_pool_);
     if (rc != RC::SUCCESS) {
       LOG_WARN("failed to open record file. filename=%s, rc=%s", record_filename.c_str(), strrc(rc));
       throw runtime_error("failed to open record file");
@@ -227,6 +228,7 @@ public:
 protected:
   DiskBufferPool   *buffer_pool_ = nullptr;
   RecordFileHandler handler_;
+  VacuousLogHandler log_handler_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/observer/storage/buffer/buffer_pool_log.cpp
+++ b/src/observer/storage/buffer/buffer_pool_log.cpp
@@ -1,0 +1,49 @@
+/* Copyright (c) 2021 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2022/02/01
+//
+
+#include "storage/buffer/buffer_pool_log.h"
+#include "storage/buffer/disk_buffer_pool.h"
+#include "storage/clog/log_handler.h"
+
+BufferPoolLogHandler::BufferPoolLogHandler(DiskBufferPool &buffer_pool, LogHandler &log_handler)
+    : buffer_pool_(buffer_pool), log_handler_(log_handler)
+{}
+
+RC BufferPoolLogHandler::allocate_page(PageNum page_num, LSN &lsn)
+{
+  return append_log(BufferPoolOperation::Type::ALLOCATE, page_num, lsn);
+}
+
+RC BufferPoolLogHandler::deallocate_page(PageNum page_num, LSN &lsn)
+{
+  return append_log(BufferPoolOperation::Type::DEALLOCATE, page_num, lsn);
+}
+
+RC BufferPoolLogHandler::flush_page(Page &page)
+{
+  return log_handler_.wait_lsn(page.lsn);
+}
+
+RC BufferPoolLogHandler::append_log(BufferPoolOperation::Type type, PageNum page_num, LSN &lsn)
+{
+  BufferPoolLogHeader header;
+  header.buffer_pool_id = buffer_pool_.id();
+  header.page_num = page_num;
+  header.operation_type = BufferPoolOperation(type).type_id();
+
+  unique_ptr<char[]> data(new char[sizeof(header)]);
+  memcpy(data.get(), &header, sizeof(header));
+
+  return log_handler_.append(lsn, LogModule::Id::BUFFER_POOL, std::move(data), sizeof(header));
+}

--- a/src/observer/storage/buffer/buffer_pool_log.cpp
+++ b/src/observer/storage/buffer/buffer_pool_log.cpp
@@ -15,6 +15,18 @@ See the Mulan PSL v2 for more details. */
 #include "storage/buffer/buffer_pool_log.h"
 #include "storage/buffer/disk_buffer_pool.h"
 #include "storage/clog/log_handler.h"
+#include "storage/clog/log_entry.h"
+
+using namespace std;
+
+string BufferPoolLogEntry::to_string() const
+{
+  return string("buffer_pool_id=") + std::to_string(buffer_pool_id) +
+         ", page_num=" + std::to_string(page_num) +
+         ", operation_type=" + BufferPoolOperation(operation_type).to_string();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 BufferPoolLogHandler::BufferPoolLogHandler(DiskBufferPool &buffer_pool, LogHandler &log_handler)
     : buffer_pool_(buffer_pool), log_handler_(log_handler)
@@ -37,13 +49,53 @@ RC BufferPoolLogHandler::flush_page(Page &page)
 
 RC BufferPoolLogHandler::append_log(BufferPoolOperation::Type type, PageNum page_num, LSN &lsn)
 {
-  BufferPoolLogHeader header;
-  header.buffer_pool_id = buffer_pool_.id();
-  header.page_num = page_num;
-  header.operation_type = BufferPoolOperation(type).type_id();
+  BufferPoolLogEntry log;
+  log.buffer_pool_id = buffer_pool_.id();
+  log.page_num = page_num;
+  log.operation_type = BufferPoolOperation(type).type_id();
 
-  unique_ptr<char[]> data(new char[sizeof(header)]);
-  memcpy(data.get(), &header, sizeof(header));
+  unique_ptr<char[]> data(new char[sizeof(log)]);
+  memcpy(data.get(), &log, sizeof(log));
 
-  return log_handler_.append(lsn, LogModule::Id::BUFFER_POOL, std::move(data), sizeof(header));
+  return log_handler_.append(lsn, LogModule::Id::BUFFER_POOL, std::move(data), sizeof(log));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// BufferPoolLogReplayer
+BufferPoolLogReplayer::BufferPoolLogReplayer(BufferPoolManager &bp_manager) : bp_manager_(bp_manager)
+{}
+
+RC BufferPoolLogReplayer::replay(const LogEntry &entry)
+{
+  if (entry.payload_size() != sizeof(BufferPoolLogEntry)) {
+    LOG_ERROR("invalid buffer pool log entry. payload size=%d, expected=%d, entry=%s",
+              entry.payload_size(), sizeof(BufferPoolLogEntry), entry.to_string().c_str());
+    return RC::INVALID_ARGUMENT;
+  }
+
+  auto log = reinterpret_cast<const BufferPoolLogEntry *>(entry.data());
+
+  LOG_TRACE("replay buffer pool log. entry=%s, log=%s", entry.to_string().c_str(), log->to_string().c_str());
+  
+  int32_t buffer_pool_id = log->buffer_pool_id;
+  DiskBufferPool *buffer_pool = nullptr;
+  RC rc = bp_manager_.get_buffer_pool(buffer_pool_id, buffer_pool);
+  if (OB_FAIL(rc) || buffer_pool == nullptr) {
+    LOG_ERROR("failed to get buffer pool. rc=%s, buffer pool=%p, log=%s, %s", 
+              strrc(rc), buffer_pool, entry.to_string().c_str(), log->to_string().c_str());
+    return rc;
+  }
+
+  BufferPoolOperation operation(log->operation_type);
+  switch (operation.type())
+  {
+    case BufferPoolOperation::Type::ALLOCATE:
+      return buffer_pool->redo_allocate_page(entry.lsn(), log->page_num);
+    case BufferPoolOperation::Type::DEALLOCATE:
+      return buffer_pool->redo_deallocate_page(entry.lsn(), log->page_num);
+    default:
+      LOG_ERROR("unknown buffer pool operation. operation=%s", operation.to_string().c_str());
+      return RC::INTERNAL;
+  }
+  return RC::SUCCESS;
 }

--- a/src/observer/storage/buffer/buffer_pool_log.h
+++ b/src/observer/storage/buffer/buffer_pool_log.h
@@ -17,8 +17,10 @@ See the Mulan PSL v2 for more details. */
 #include <string>
 #include "common/types.h"
 #include "common/rc.h"
+#include "storage/clog/log_replayer.h"
 
 class DiskBufferPool;
+class BufferPoolManager;
 class LogHandler;
 struct Page;
 
@@ -57,11 +59,13 @@ private:
   Type type_;
 };
 
-struct BufferPoolLogHeader
+struct BufferPoolLogEntry
 {
   int32_t  buffer_pool_id;  /// buffer pool id
   int32_t  operation_type;  /// operation type
   PageNum  page_num;        /// page number
+
+  std::string to_string() const;
 };
 
 class BufferPoolLogHandler final
@@ -80,4 +84,16 @@ private:
 private:
   DiskBufferPool &buffer_pool_;
   LogHandler &log_handler_;
+};
+
+class BufferPoolLogReplayer final : public LogReplayer
+{
+public:
+  BufferPoolLogReplayer(BufferPoolManager &bp_manager);
+  virtual ~BufferPoolLogReplayer() = default;
+
+  RC replay(const LogEntry &entry) override;
+
+private:
+  BufferPoolManager &bp_manager_;
 };

--- a/src/observer/storage/buffer/buffer_pool_log.h
+++ b/src/observer/storage/buffer/buffer_pool_log.h
@@ -1,0 +1,83 @@
+/* Copyright (c) 2021 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2022/02/01
+//
+
+#pragma once
+
+#include <string>
+#include "common/types.h"
+#include "common/rc.h"
+
+class DiskBufferPool;
+class LogHandler;
+struct Page;
+
+class BufferPoolOperation
+{
+public:
+  enum class Type : int32_t
+  {
+    ALLOCATE,
+    DEALLOCATE
+  };
+
+public:
+  BufferPoolOperation(Type type) : type_(type) {}
+  BufferPoolOperation(int32_t type) : type_(static_cast<Type>(type)) {}
+  ~BufferPoolOperation() = default;
+
+  Type type() const { return type_; }
+  int32_t type_id() const { return static_cast<int32_t>(type_); }
+
+  std::string to_string() const
+  {
+    std::string ret = std::to_string(type_id()) + ":";
+    switch (type_)
+    {
+    case Type::ALLOCATE:
+      return ret + "ALLOCATE";
+    case Type::DEALLOCATE:
+      return ret + "DEALLOCATE";
+    default:
+      return ret + "UNKNOWN";
+    }
+  }
+
+private:
+  Type type_;
+};
+
+struct BufferPoolLogHeader
+{
+  int32_t  buffer_pool_id;  /// buffer pool id
+  int32_t  operation_type;  /// operation type
+  PageNum  page_num;        /// page number
+};
+
+class BufferPoolLogHandler final
+{
+public:
+  BufferPoolLogHandler(DiskBufferPool &buffer_pool, LogHandler &log_handler);
+  ~BufferPoolLogHandler() = default;
+
+  RC allocate_page(PageNum page_num, LSN &lsn);
+  RC deallocate_page(PageNum page_num, LSN &lsn);
+  RC flush_page(Page &page);
+
+private:
+  RC append_log(BufferPoolOperation::Type type, PageNum page_num, LSN &lsn);
+
+private:
+  DiskBufferPool &buffer_pool_;
+  LogHandler &log_handler_;
+};

--- a/src/observer/storage/buffer/disk_buffer_pool.h
+++ b/src/observer/storage/buffer/disk_buffer_pool.h
@@ -33,9 +33,12 @@ See the Mulan PSL v2 for more details. */
 #include "common/types.h"
 #include "storage/buffer/frame.h"
 #include "storage/buffer/page.h"
+#include "storage/buffer/buffer_pool_log.h"
 
 class BufferPoolManager;
 class DiskBufferPool;
+class LogHandler;
+class BufferPoolLogHandler;
 
 /**
  * @brief BufferPool 的实现
@@ -57,6 +60,7 @@ class DiskBufferPool;
  */
 struct BPFileHeader
 {
+  int32_t buffer_pool_id;   //! buffer pool id
   int32_t page_count;       //! 当前文件一共有多少个页面
   int32_t allocated_pages;  //! 已经分配了多少个页面
   char    bitmap[0];        //! 页面分配位图, 第0个页面(就是当前页面)，总是1
@@ -175,17 +179,14 @@ private:
 /**
  * @brief BufferPool的实现
  * @ingroup BufferPool
+ * @details 一个文件被划分成多个相同大小的页面，并在需要访问的时候，会从文件读取到内存中。
+ * DiskBufferPool 就负责管理磁盘文件，以及负责管理页面在文件与内存中的交互，比如读取、写回。
  */
-class DiskBufferPool
+class DiskBufferPool final
 {
 public:
-  DiskBufferPool(BufferPoolManager &bp_manager, BPFrameManager &frame_manager);
+  DiskBufferPool(BufferPoolManager &bp_manager, BPFrameManager &frame_manager, LogHandler &log_handler);
   ~DiskBufferPool();
-
-  /**
-   * 创建一个名称为指定文件名的分页文件
-   */
-  RC create_file(const char *file_name);
 
   /**
    * 根据文件名打开一个分页文件
@@ -255,6 +256,9 @@ public:
    */
   RC recover_page(PageNum page_num);
 
+public:
+  int32_t id() const { return file_header_->buffer_pool_id; }
+
 protected:
   RC allocate_frame(PageNum page_num, Frame **buf);
 
@@ -275,14 +279,15 @@ protected:
   RC flush_page_internal(Frame &frame);
 
 private:
-  BufferPoolManager &bp_manager_;
-  BPFrameManager    &frame_manager_;
+  BufferPoolManager &bp_manager_;     /// BufferPool 管理器
+  BPFrameManager    &frame_manager_;  /// Frame 管理器
+  BufferPoolLogHandler log_handler_; /// BufferPool 日志处理器
 
-  std::string       file_name_;
-  int               file_desc_   = -1;
-  Frame            *hdr_frame_   = nullptr;
-  BPFileHeader     *file_header_ = nullptr;
-  std::set<PageNum> disposed_pages_;
+  std::string       file_name_;       /// 文件名
+  int               file_desc_   = -1;  /// 文件描述符
+  Frame            *hdr_frame_   = nullptr; /// 文件头页面
+  BPFileHeader     *file_header_ = nullptr; /// 文件头
+  std::set<PageNum> disposed_pages_; /// 已经释放的页面
 
   common::Mutex lock_;
 
@@ -301,13 +306,14 @@ public:
   ~BufferPoolManager();
 
   RC create_file(const char *file_name);
-  RC open_file(const char *file_name, DiskBufferPool *&bp);
+  RC open_file(LogHandler &log_handler, const char *file_name, DiskBufferPool *&bp);
   RC close_file(const char *file_name);
 
   RC flush_page(Frame &frame);
 
 public:
-  static void               set_instance(BufferPoolManager *bpm);  // TODO 优化全局变量的表示方法
+  static void set_instance(BufferPoolManager *bpm);  // TODO 优化全局变量的表示方法
+
   static BufferPoolManager &instance();
 
 private:
@@ -316,4 +322,6 @@ private:
   common::Mutex                                     lock_;
   std::unordered_map<std::string, DiskBufferPool *> buffer_pools_;
   std::unordered_map<int, DiskBufferPool *>         fd_buffer_pools_;
+  std::unordered_map<int32_t, DiskBufferPool *>     id_to_buffer_pools_;  // TODO fd_buffer_pool 与 id_to_buffer_pool保留一个就可以
+  std::atomic<int32_t> next_buffer_pool_id_{1}; // 系统启动时，会打开所有的表，这样就可以知道当前系统最大的ID是多少了
 };

--- a/src/observer/storage/buffer/disk_buffer_pool.h
+++ b/src/observer/storage/buffer/disk_buffer_pool.h
@@ -204,8 +204,8 @@ public:
   RC get_this_page(PageNum page_num, Frame **frame);
 
   /**
-   * 在指定文件中分配一个新的页面，并将其放入缓冲区，返回页面句柄指针。
-   * 分配页面时，如果文件中有空闲页，就直接分配一个空闲页；
+   * @brief 在指定文件中分配一个新的页面，并将其放入缓冲区，返回页面句柄指针。
+   * @details 分配页面时，如果文件中有空闲页，就直接分配一个空闲页；
    * 如果文件中没有空闲页，则扩展文件规模来增加新的空闲页。
    */
   RC allocate_page(Frame **frame);
@@ -255,6 +255,9 @@ public:
    * 回放日志时处理page0中已被认定为不存在的page
    */
   RC recover_page(PageNum page_num);
+
+  RC redo_allocate_page(LSN lsn, PageNum page_num);
+  RC redo_deallocate_page(LSN lsn, PageNum page_num);
 
 public:
   int32_t id() const { return file_header_->buffer_pool_id; }
@@ -310,6 +313,14 @@ public:
   RC close_file(const char *file_name);
 
   RC flush_page(Frame &frame);
+
+  /**
+   * @brief 根据ID获取对应的BufferPool对象
+   * @details 在做redo时，需要根据ID获取对应的BufferPool对象，然后让bufferPool对象自己做redo
+   * @param id buffer pool id
+   * @param bp buffer pool 对象
+   */
+  RC get_buffer_pool(int32_t id, DiskBufferPool *&bp);
 
 public:
   static void set_instance(BufferPoolManager *bpm);  // TODO 优化全局变量的表示方法

--- a/src/observer/storage/buffer/frame.h
+++ b/src/observer/storage/buffer/frame.h
@@ -91,9 +91,9 @@ public:
    * @brief 每个页面都有一个编号
    * @details 当前页面编号记录在了页面数据中，其实可以不记录，从磁盘中加载时记录在Frame信息中即可。
    */
-  PageNum page_num() const { return page_.page_num; }
-  void    set_page_num(PageNum page_num) { page_.page_num = page_num; }
-  FrameId frame_id() const { return FrameId(file_desc_, page_.page_num); }
+  PageNum page_num() const { return page_num_; }
+  void    set_page_num(PageNum page_num) { page_num_ = page_num; }
+  FrameId frame_id() const { return FrameId(file_desc_, page_num_); }
 
   /**
    * @brief 为了实现持久化，需要将页面的修改记录记录到日志中，这里记录了日志序列号
@@ -164,6 +164,7 @@ private:
   bool             dirty_ = false;
   std::atomic<int> pin_count_{0};
   unsigned long    acc_time_  = 0;
+  PageNum          page_num_ = -1;
   int              file_desc_ = -1;
   Page             page_;
 

--- a/src/observer/storage/buffer/frame.h
+++ b/src/observer/storage/buffer/frame.h
@@ -79,21 +79,49 @@ public:
 
   int     file_desc() const { return file_desc_; }
   void    set_file_desc(int fd) { file_desc_ = fd; }
+
+  /**
+   * @brief 在磁盘和内存中内容完全一致的数据页
+   * @details 磁盘文件划分为一个个页面，每次从磁盘加载到内存中，也是一个页面，就是 Page。
+   * frame 是为了管理这些页面而维护的一个数据结构。
+   */
   Page   &page() { return page_; }
+
+  /**
+   * @brief 每个页面都有一个编号
+   * @details 当前页面编号记录在了页面数据中，其实可以不记录，从磁盘中加载时记录在Frame信息中即可。
+   */
   PageNum page_num() const { return page_.page_num; }
   void    set_page_num(PageNum page_num) { page_.page_num = page_num; }
   FrameId frame_id() const { return FrameId(file_desc_, page_.page_num); }
+
+  /**
+   * @brief 为了实现持久化，需要将页面的修改记录记录到日志中，这里记录了日志序列号
+   * @details 如果当前页面从磁盘中加载出来时，它的日志序列号比当前WAL(Write-Ahead-Logging)中的一些
+   * 序列号要小，那就可以从日志中读取这些更大序列号的日志，做重做操作，将页面恢复到最新状态，也就是redo。
+   */
   LSN     lsn() const { return page_.lsn; }
   void    set_lsn(LSN lsn) { page_.lsn = lsn; }
 
-  /// 刷新访问时间 TODO touch is better?
+  /**
+   * @brief 刷新当前内存页面的访问时间
+   * @details 由于内存是有限的，比磁盘要小很多。那当我们访问某些文件页面时，可能由于内存不足
+   * 而要淘汰一些页面。我们选择淘汰哪些页面呢？这里使用了LRU算法，即最近最少使用的页面被淘汰。
+   * 最近最少使用，采用的依据就是访问时间。所以每次访问某个页面时，我们都要刷新一下访问时间。
+   */
   void access();
 
   /**
-   * @brief 标记指定页面为“脏”页。如果修改了页面的内容，则应调用此函数，
+   * @brief 标记指定页面为“脏”页。
+   * @details 如果修改了页面的内容，则应调用此函数，
    * 以便该页面被淘汰出缓冲区时系统将新的页面数据写入磁盘文件
    */
   void mark_dirty() { dirty_ = true; }
+
+  /**
+   * @brief 重置“脏”标记
+   * @details 如果页面已经被写入磁盘文件，则应调用此函数。
+   */
   void clear_dirty() { dirty_ = false; }
   bool dirty() const { return dirty_; }
 
@@ -103,7 +131,8 @@ public:
 
   /**
    * @brief 给当前页帧增加引用计数
-   * pin通常都会加着frame manager锁来访问
+   * pin通常都会加着frame manager锁来访问。
+   * 当我们访问某个页面时，我们不期望此页面被淘汰，所以我们会增加引用计数。
    */
   void pin();
 

--- a/src/observer/storage/buffer/page.h
+++ b/src/observer/storage/buffer/page.h
@@ -24,7 +24,7 @@ static constexpr int BP_INVALID_PAGE_NUM = -1;
 static constexpr PageNum BP_HEADER_PAGE = 0;
 
 static constexpr const int BP_PAGE_SIZE      = (1 << 13);
-static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(PageNum) - sizeof(LSN));
+static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(LSN));
 
 /**
  * @brief 表示一个页面，可能放在内存或磁盘上
@@ -32,7 +32,6 @@ static constexpr const int BP_PAGE_DATA_SIZE = (BP_PAGE_SIZE - sizeof(PageNum) -
  */
 struct Page
 {
-  PageNum page_num;
   LSN     lsn;
   char    data[BP_PAGE_DATA_SIZE];
 };

--- a/src/observer/storage/clog/disk_log_handler.cpp
+++ b/src/observer/storage/clog/disk_log_handler.cpp
@@ -1,0 +1,192 @@
+/* Copyright (c) 2021-2022 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2024/01/30
+//
+
+#include "common/thread/thread_util.h"
+#include "storage/clog/disk_log_handler.h"
+#include "storage/clog/log_file.h"
+#include "storage/clog/log_replayer.h"
+
+using namespace std;
+using namespace common;
+
+////////////////////////////////////////////////////////////////////////////////
+// LogHandler
+
+RC DiskLogHandler::init(const char *path)
+{
+  const int max_entry_number_per_file = 1000;
+  return file_manager_.init(path, max_entry_number_per_file);
+}
+
+RC DiskLogHandler::start()
+{
+  if (thread_) {
+    LOG_ERROR("log has been started");
+    return RC::INTERNAL;
+  }
+
+  running_.store(true);
+  thread_ = make_unique<thread>(&DiskLogHandler::thread_func, this);
+  LOG_INFO("log handler started");
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::stop()
+{
+  if (!thread_) {
+    LOG_ERROR("log has not been started");
+    return RC::INTERNAL;
+  }
+
+  running_.store(false);
+
+  LOG_INFO("log handler stopped");
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::wait()
+{
+  if (!thread_) {
+    LOG_ERROR("log has not been started");
+    return RC::INTERNAL;
+  }
+
+  if (running_.load()) {
+    LOG_ERROR("log handler is running");
+    return RC::INTERNAL;
+  }
+
+  thread_->join();
+  thread_.reset();
+  LOG_INFO("log handler joined");
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::replay(LogReplayer &replayer, LSN start_lsn)
+{
+  LSN max_lsn = 0;
+  auto replay_callback = [&replayer, &max_lsn](LogEntry &entry) -> RC {
+    if (entry.lsn() > max_lsn) {
+      max_lsn = entry.lsn();
+    }
+    return replayer.replay(entry);
+  };
+
+  RC rc = iterate(replay_callback, start_lsn);
+  if (OB_FAIL(rc)) {
+    LOG_WARN("failed to iterate log entries. rc=%s", strrc(rc));
+    return rc;
+  }
+
+  rc = entry_buffer_.init(max_lsn);
+  if (OB_FAIL(rc)) {
+    LOG_WARN("failed to init log entry buffer. rc=%s", strrc(rc));
+    return rc;
+  }
+
+  LOG_INFO("replay clog files done. start lsn=%ld, max_lsn=%ld", start_lsn, max_lsn);
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::iterate(std::function<RC(LogEntry&)> consumer, LSN start_lsn)
+{
+  vector<string> log_files;
+  RC rc = file_manager_.list_files(log_files, start_lsn);
+  if (OB_FAIL(rc)) {
+    LOG_WARN("failed to list clog files. rc=%s", strrc(rc));
+    return rc;
+  }
+
+  for (auto &file : log_files) {
+    LogFileReader file_handle;
+    rc = file_handle.open(file.c_str());
+    if (OB_FAIL(rc)) {
+      LOG_WARN("failed to open clog file. rc=%s, file=%s", strrc(rc), file.c_str());
+      return rc;
+    }
+
+    rc = file_handle.iterate(consumer, start_lsn);
+    if (OB_FAIL(rc)) {
+      LOG_WARN("failed to iterate clog file. rc=%s, file=%s", strrc(rc), file.c_str());
+      return rc;
+    }
+
+    rc = file_handle.close();
+    if (OB_FAIL(rc)) {
+      LOG_WARN("failed to close clog file. rc=%s, file=%s", strrc(rc), file.c_str());
+      return rc;
+    }
+  }
+
+  LOG_INFO("iterate clog files done. rc=%s", strrc(rc));
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::_append(LSN &lsn, LogModule module, unique_ptr<char[]> data, int32_t size)
+{
+  RC rc = entry_buffer_.append(lsn, module, std::move(data), size);
+  if (OB_FAIL(rc)) {
+    LOG_WARN("failed to append log entry to buffer. rc=%s", strrc(rc));
+    return rc;
+  }
+
+  return RC::SUCCESS;
+}
+
+RC DiskLogHandler::wait_lsn(LSN lsn)
+{
+  while (running_.load() && current_flushed_lsn() < lsn) {
+    this_thread::sleep_for(chrono::milliseconds(1000));
+  }
+
+  return RC::SUCCESS;
+}
+
+void DiskLogHandler::thread_func()
+{
+  thread_set_name("LogHandler");
+  LOG_INFO("log handler thread started");
+
+  LogFileWriter file_writer;
+  
+  RC rc = RC::SUCCESS;
+  while (running_.load() || entry_buffer_.entry_number() > 0) {
+    if (!file_writer.valid() || rc == RC::LOG_FILE_FULL) {
+      if (rc == RC::LOG_FILE_FULL) {
+        rc = file_manager_.next_file(file_writer);
+      } else {
+        rc = file_manager_.last_file(file_writer);
+      }
+      if (OB_FAIL(rc)) {
+        LOG_WARN("failed to open log file. rc=%s", strrc(rc));
+        this_thread::sleep_for(chrono::milliseconds(1000));
+        continue;
+      }
+      LOG_INFO("open log file success. file=%s", file_writer.to_string().c_str());
+    }
+
+    int flush_count = 0;
+    rc = entry_buffer_.flush(file_writer, flush_count);
+    if (OB_FAIL(rc) && RC::LOG_FILE_FULL != rc) {
+      LOG_WARN("failed to flush log entry buffer. rc=%s", strrc(rc));
+    }
+
+    if (flush_count == 0 && rc == RC::SUCCESS) {
+      this_thread::sleep_for(chrono::milliseconds(1000));
+      continue;
+    }
+  }
+
+  LOG_INFO("log handler thread stopped");
+}

--- a/src/observer/storage/clog/disk_log_handler.cpp
+++ b/src/observer/storage/clog/disk_log_handler.cpp
@@ -135,6 +135,9 @@ RC DiskLogHandler::iterate(std::function<RC(LogEntry&)> consumer, LSN start_lsn)
 
 RC DiskLogHandler::_append(LSN &lsn, LogModule module, unique_ptr<char[]> data, int32_t size)
 {
+  ASSERT(running_.load(), "log handler is not running. lsn=%ld, module=%s, size=%d", 
+        lsn, module.name(), size);
+
   RC rc = entry_buffer_.append(lsn, module, std::move(data), size);
   if (OB_FAIL(rc)) {
     LOG_WARN("failed to append log entry to buffer. rc=%s", strrc(rc));

--- a/src/observer/storage/clog/disk_log_handler.h
+++ b/src/observer/storage/clog/disk_log_handler.h
@@ -1,0 +1,75 @@
+/* Copyright (c) 2021-2022 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2024/02/01
+//
+
+#pragma once
+
+#include <thread>
+#include <memory>
+#include <deque>
+#include <vector>
+
+#include "common/types.h"
+#include "common/rc.h"
+#include "storage/clog/log_module.h"
+#include "storage/clog/log_file.h"
+#include "storage/clog/log_buffer.h"
+#include "storage/clog/log_handler.h"
+
+class LogReplayer;
+
+/**
+ * @brief 对外提供服务的CLog模块
+ * @ingroup CLog
+ * @details 该模块负责日志的写入、读取、回放等功能。
+ * 会在后台开启一个线程，一直尝试刷新内存中的日志到磁盘。
+ * 所有的CLog日志文件都存放在指定的目录下，每个日志文件按照日志条数来划分。
+ */
+class DiskLogHandler : public LogHandler
+{
+public:
+  DiskLogHandler() = default;
+  virtual ~DiskLogHandler() = default;
+
+  /**
+   * @brief 初始化日志模块
+   * 
+   * @param path 日志文件存放的目录
+   */
+  RC init(const char *path);
+  RC start();
+  RC stop();
+  RC wait();
+
+  RC replay(LogReplayer &replayer, LSN start_lsn) override;
+  RC iterate(std::function<RC(LogEntry&)> consumer, LSN start_lsn) override;
+
+  RC wait_lsn(LSN lsn) override;
+
+  LSN current_lsn() const { return entry_buffer_.current_lsn(); }
+  LSN current_flushed_lsn() const { return entry_buffer_.flushed_lsn(); }
+
+private:
+  RC _append(LSN &lsn, LogModule module, std::unique_ptr<char[]> data, int32_t size) override;
+private:
+  void thread_func();
+
+private:
+  std::unique_ptr<std::thread> thread_;
+  std::atomic_bool running_{false};
+
+  LogFileManager file_manager_;
+  LogEntryBuffer entry_buffer_;
+
+  std::string path_;
+};

--- a/src/observer/storage/clog/log_file.cpp
+++ b/src/observer/storage/clog/log_file.cpp
@@ -16,7 +16,7 @@ See the Mulan PSL v2 for more details. */
 #include <charconv>
 #include "common/log/log.h"
 #include "storage/clog/log_file.h"
-#include "storage/clog/log_handler.h"
+#include "storage/clog/log_entry.h"
 #include "common/io/io.h"
 
 using namespace std;
@@ -183,8 +183,6 @@ RC LogFileWriter::write(LogEntry &entry)
   if (fd_ < 0) {
     return RC::FILE_NOT_OPENED;
   }
-
-  ASSERT(entry.lsn() > 0 && entry.payload_size() >= 0, "invalid log entry. entry=%s", entry.to_string().c_str());
 
   if (entry.lsn() <= last_lsn_) {
     LOG_WARN("write log entry failed. lsn is too small. filename=%s, last_lsn=%ld, entry=%s", 

--- a/src/observer/storage/clog/vacuous_log_handler.h
+++ b/src/observer/storage/clog/vacuous_log_handler.h
@@ -12,18 +12,24 @@ See the Mulan PSL v2 for more details. */
 // Created by wangyunlai on 2024/02/01
 //
 
+#pragma once
+
 #include "storage/clog/log_handler.h"
 
-using namespace std;
 
-RC LogHandler::append(LSN &lsn, LogModule::Id module, const char *data, int32_t size)
+// VacuousLogHandler is a log handler implenmentation that do nothing in all methods.
+// It is used for testing.
+class VacuousLogHandler : public LogHandler
 {
-  unique_ptr<char[]> buf(new char[size]);
-  memcpy(buf.get(), data, size);
-  return append(lsn, module, std::move(buf), size);
-}
+public:
+  VacuousLogHandler() = default;
+  ~VacuousLogHandler() = default;
 
-RC LogHandler::append(LSN &lsn, LogModule::Id module, std::unique_ptr<char[]> data, int32_t size)
-{
-  return _append(lsn, LogModule(module), std::move(data), size);
-}
+  RC replay(LogReplayer &replayer, LSN start_lsn) override { return RC::SUCCESS; }
+  RC iterate(std::function<RC(LogEntry&)> consumer, LSN start_lsn) override { return RC::SUCCESS; }
+
+  RC wait_lsn(LSN lsn) override { return RC::SUCCESS; }
+
+private:
+  RC _append(LSN &lsn, LogModule module, std::unique_ptr<char[]> data, int32_t size) override { return RC::SUCCESS; }
+};

--- a/src/observer/storage/db/db.h
+++ b/src/observer/storage/db/db.h
@@ -21,9 +21,11 @@ See the Mulan PSL v2 for more details. */
 
 #include "common/rc.h"
 #include "sql/parser/parse_defs.h"
+#include "storage/clog/disk_log_handler.h"
 
 class Table;
 class CLogManager;
+class LogHandler;
 
 /**
  * @brief 一个DB实例负责管理一批表
@@ -59,6 +61,7 @@ public:
   RC recover();
 
   CLogManager *clog_manager();
+  LogHandler &log_handler();
 
 private:
   RC open_all_tables();
@@ -68,6 +71,7 @@ private:
   std::string                              path_;
   std::unordered_map<std::string, Table *> opened_tables_;
   std::unique_ptr<CLogManager>             clog_manager_;
+  std::unique_ptr<DiskLogHandler>          log_handler_;
 
   /// 给每个table都分配一个ID，用来记录日志。这里假设所有的DDL都不会并发操作，所以相关的数据都不上锁
   int32_t next_table_id_ = 0;

--- a/src/observer/storage/index/bplus_tree.cpp
+++ b/src/observer/storage/index/bplus_tree.cpp
@@ -686,8 +686,12 @@ RC BplusTreeHandler::sync()
   return disk_buffer_pool_->flush_all_pages();
 }
 
-RC BplusTreeHandler::create(const char *file_name, AttrType attr_type, int attr_length, int internal_max_size /* = -1*/,
-    int leaf_max_size /* = -1 */)
+RC BplusTreeHandler::create(LogHandler &log_handler, 
+                            const char *file_name, 
+                            AttrType attr_type, 
+                            int attr_length, 
+                            int internal_max_size /* = -1*/,
+                            int leaf_max_size /* = -1 */)
 {
   BufferPoolManager &bpm = BufferPoolManager::instance();
 
@@ -700,7 +704,7 @@ RC BplusTreeHandler::create(const char *file_name, AttrType attr_type, int attr_
 
   DiskBufferPool *bp = nullptr;
 
-  rc = bpm.open_file(file_name, bp);
+  rc = bpm.open_file(log_handler, file_name, bp);
   if (rc != RC::SUCCESS) {
     LOG_WARN("Failed to open file. file name=%s, rc=%d:%s", file_name, rc, strrc(rc));
     return rc;
@@ -762,7 +766,7 @@ RC BplusTreeHandler::create(const char *file_name, AttrType attr_type, int attr_
   return RC::SUCCESS;
 }
 
-RC BplusTreeHandler::open(const char *file_name)
+RC BplusTreeHandler::open(LogHandler &log_handler, const char *file_name)
 {
   if (disk_buffer_pool_ != nullptr) {
     LOG_WARN("%s has been opened before index.open.", file_name);
@@ -772,7 +776,7 @@ RC BplusTreeHandler::open(const char *file_name)
   BufferPoolManager &bpm              = BufferPoolManager::instance();
   DiskBufferPool    *disk_buffer_pool = nullptr;
 
-  RC rc = bpm.open_file(file_name, disk_buffer_pool);
+  RC rc = bpm.open_file(log_handler, file_name, disk_buffer_pool);
   if (rc != RC::SUCCESS) {
     LOG_WARN("Failed to open file name=%s, rc=%d:%s", file_name, rc, strrc(rc));
     return rc;

--- a/src/observer/storage/index/bplus_tree.h
+++ b/src/observer/storage/index/bplus_tree.h
@@ -29,6 +29,8 @@ See the Mulan PSL v2 for more details. */
 #include "storage/record/record_manager.h"
 #include "storage/trx/latch_memo.h"
 
+class LogHandler;
+
 /**
  * @brief B+树的实现
  * @defgroup BPlusTree
@@ -442,15 +444,19 @@ public:
    * 此函数创建一个名为fileName的索引。
    * attrType描述被索引属性的类型，attrLength描述被索引属性的长度
    */
-  RC create(
-      const char *file_name, AttrType attr_type, int attr_length, int internal_max_size = -1, int leaf_max_size = -1);
+  RC create(LogHandler &log_handler,
+            const char *file_name, 
+            AttrType attr_type, 
+            int attr_length, 
+            int internal_max_size = -1, 
+            int leaf_max_size = -1);
 
   /**
    * 打开名为fileName的索引文件。
    * 如果方法调用成功，则indexHandle为指向被打开的索引句柄的指针。
    * 索引句柄用于在索引中插入或删除索引项，也可用于索引的扫描
    */
-  RC open(const char *file_name);
+  RC open(LogHandler &log_handler, const char *file_name);
 
   /**
    * 关闭句柄indexHandle对应的索引文件

--- a/src/observer/storage/index/bplus_tree_index.cpp
+++ b/src/observer/storage/index/bplus_tree_index.cpp
@@ -14,10 +14,12 @@ See the Mulan PSL v2 for more details. */
 
 #include "storage/index/bplus_tree_index.h"
 #include "common/log/log.h"
+#include "storage/table/table.h"
+#include "storage/db/db.h"
 
 BplusTreeIndex::~BplusTreeIndex() noexcept { close(); }
 
-RC BplusTreeIndex::create(const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta)
+RC BplusTreeIndex::create(Table *table, const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta)
 {
   if (inited_) {
     LOG_WARN("Failed to create index due to the index has been created before. file_name:%s, index:%s, field:%s",
@@ -27,7 +29,7 @@ RC BplusTreeIndex::create(const char *file_name, const IndexMeta &index_meta, co
 
   Index::init(index_meta, field_meta);
 
-  RC rc = index_handler_.create(file_name, field_meta.type(), field_meta.len());
+  RC rc = index_handler_.create(table->db()->log_handler(), file_name, field_meta.type(), field_meta.len());
   if (RC::SUCCESS != rc) {
     LOG_WARN("Failed to create index_handler, file_name:%s, index:%s, field:%s, rc:%s",
         file_name, index_meta.name(), index_meta.field(), strrc(rc));
@@ -35,12 +37,13 @@ RC BplusTreeIndex::create(const char *file_name, const IndexMeta &index_meta, co
   }
 
   inited_ = true;
+  table_  = table;
   LOG_INFO("Successfully create index, file_name:%s, index:%s, field:%s",
     file_name, index_meta.name(), index_meta.field());
   return RC::SUCCESS;
 }
 
-RC BplusTreeIndex::open(const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta)
+RC BplusTreeIndex::open(Table *table, const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta)
 {
   if (inited_) {
     LOG_WARN("Failed to open index due to the index has been initedd before. file_name:%s, index:%s, field:%s",
@@ -50,7 +53,7 @@ RC BplusTreeIndex::open(const char *file_name, const IndexMeta &index_meta, cons
 
   Index::init(index_meta, field_meta);
 
-  RC rc = index_handler_.open(file_name);
+  RC rc = index_handler_.open(table->db()->log_handler(), file_name);
   if (RC::SUCCESS != rc) {
     LOG_WARN("Failed to open index_handler, file_name:%s, index:%s, field:%s, rc:%s",
         file_name, index_meta.name(), index_meta.field(), strrc(rc));
@@ -58,6 +61,7 @@ RC BplusTreeIndex::open(const char *file_name, const IndexMeta &index_meta, cons
   }
 
   inited_ = true;
+  table_  = table;
   LOG_INFO("Successfully open index, file_name:%s, index:%s, field:%s",
     file_name, index_meta.name(), index_meta.field());
   return RC::SUCCESS;

--- a/src/observer/storage/index/bplus_tree_index.h
+++ b/src/observer/storage/index/bplus_tree_index.h
@@ -27,8 +27,8 @@ public:
   BplusTreeIndex() = default;
   virtual ~BplusTreeIndex() noexcept;
 
-  RC create(const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta);
-  RC open(const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta);
+  RC create(Table *table, const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta);
+  RC open(Table *table, const char *file_name, const IndexMeta &index_meta, const FieldMeta &field_meta);
   RC close();
 
   RC insert_entry(const char *record, const RID *rid) override;
@@ -44,6 +44,7 @@ public:
 
 private:
   bool             inited_ = false;
+  Table *          table_  = nullptr;
   BplusTreeHandler index_handler_;
 };
 

--- a/src/observer/storage/record/record_manager.cpp
+++ b/src/observer/storage/record/record_manager.cpp
@@ -325,7 +325,7 @@ RC RecordFileHandler::init_free_pages()
   RC rc = RC::SUCCESS;
 
   BufferPoolIterator bp_iterator;
-  bp_iterator.init(*disk_buffer_pool_);
+  bp_iterator.init(*disk_buffer_pool_, 1);
   RecordPageHandler record_page_handler;
   PageNum           current_page_num = 0;
 
@@ -504,7 +504,7 @@ RC RecordFileScanner::open_scan(
   trx_              = trx;
   readonly_         = readonly;
 
-  RC rc = bp_iterator_.init(buffer_pool);
+  RC rc = bp_iterator_.init(buffer_pool, 1);
   if (rc != RC::SUCCESS) {
     LOG_WARN("failed to init bp iterator. rc=%d:%s", rc, strrc(rc));
     return rc;

--- a/src/observer/storage/table/table.h
+++ b/src/observer/storage/table/table.h
@@ -28,6 +28,7 @@ class Index;
 class IndexScanner;
 class RecordDeleter;
 class Trx;
+class Db;
 
 /**
  * @brief 表
@@ -47,7 +48,7 @@ public:
    * @param attribute_count 字段个数
    * @param attributes 字段
    */
-  RC create(int32_t table_id, const char *path, const char *name, const char *base_dir, int attribute_count,
+  RC create(Db *db, int32_t table_id, const char *path, const char *name, const char *base_dir, int attribute_count,
       const AttrInfoSqlNode attributes[]);
 
   /**
@@ -55,7 +56,7 @@ public:
    * @param meta_file 保存表元数据的文件完整路径
    * @param base_dir 表所在的文件夹，表记录数据文件、索引数据文件存放位置
    */
-  RC open(const char *meta_file, const char *base_dir);
+  RC open(Db *db, const char *meta_file, const char *base_dir);
 
   /**
    * @brief 根据给定的字段生成一个记录/行
@@ -88,6 +89,8 @@ public:
 public:
   int32_t     table_id() const { return table_meta_.table_id(); }
   const char *name() const;
+  
+  Db *db() const { return db_; }
 
   const TableMeta &table_meta() const;
 
@@ -105,6 +108,7 @@ public:
   Index *find_index_by_field(const char *field_name) const;
 
 private:
+  Db *                 db_ = nullptr;
   std::string          base_dir_;
   TableMeta            table_meta_;
   DiskBufferPool      *data_buffer_pool_ = nullptr;  /// 数据文件关联的buffer pool

--- a/unittest/bplus_tree_test.cpp
+++ b/unittest/bplus_tree_test.cpp
@@ -19,6 +19,7 @@ See the Mulan PSL v2 for more details. */
 #include "sql/parser/parse_defs.h"
 #include "storage/buffer/disk_buffer_pool.h"
 #include "storage/index/bplus_tree.h"
+#include "storage/clog/vacuous_log_handler.h"
 #include "gtest/gtest.h"
 
 using namespace common;
@@ -466,10 +467,12 @@ TEST(test_bplus_tree, test_chars)
 {
   LoggerFactory::init_default("test_chars.log");
 
+  VacuousLogHandler log_handler;
+
   const char *index_name = "chars.btree";
   ::remove(index_name);
   handler = new BplusTreeHandler();
-  handler->create(index_name, CHARS, 8, ORDER, ORDER);
+  handler->create(log_handler, index_name, CHARS, 8, ORDER, ORDER);
 
   char keys[][9] = {"abcdefg", "12345678", "12345678", "abcdefg", "abcdefga"};
 
@@ -503,10 +506,12 @@ TEST(test_bplus_tree, test_scanner)
 {
   LoggerFactory::init_default("test.log");
 
+  VacuousLogHandler log_handler;
+
   const char *index_name = "scanner.btree";
   ::remove(index_name);
   handler = new BplusTreeHandler();
-  handler->create(index_name, INTS, sizeof(int), ORDER, ORDER);
+  handler->create(log_handler, index_name, INTS, sizeof(int), ORDER, ORDER);
 
   int count = 0;
   RC  rc    = RC::SUCCESS;
@@ -713,9 +718,10 @@ TEST(test_bplus_tree, test_bplus_tree_insert)
 {
   LoggerFactory::init_default("test.log");
 
+  VacuousLogHandler log_handler;
   ::remove(index_name);
   handler = new BplusTreeHandler();
-  handler->create(index_name, INTS, sizeof(int), ORDER, ORDER);
+  handler->create(log_handler, index_name, INTS, sizeof(int), ORDER, ORDER);
 
   test_insert();
 

--- a/unittest/buffer_pool_log_test.cpp
+++ b/unittest/buffer_pool_log_test.cpp
@@ -1,0 +1,395 @@
+/* Copyright (c) 2021-2022 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2024/02/01
+//
+
+#include "gtest/gtest.h"
+#include "common/log/log.h"
+#include "storage/buffer/disk_buffer_pool.h"
+#include "storage/clog/disk_log_handler.h"
+#include "storage/buffer/buffer_pool_log.h"
+
+using namespace std;
+using namespace common;
+
+int buffer_pool_page_count(DiskBufferPool *buffer_pool)
+{
+  int count = 0;
+  BufferPoolIterator iterator;
+  iterator.init(*buffer_pool, 1);
+  while (iterator.has_next()) {
+    iterator.next();
+    count++;
+  }
+  return count;
+}
+
+TEST(BufferPoolLog, test_wal_normal)
+{
+  /// 测试正常关闭的情况重做日志
+
+  filesystem::path test_path("test_disk_buffer_pool_wal_normal");
+  filesystem::path clog_path = test_path / "clog";
+
+  filesystem::remove_all(test_path);
+  filesystem::create_directory(test_path);
+
+  filesystem::path buffer_pool_filename = test_path / "buffer_pool.bp";
+  BufferPoolManager buffer_pool_manager;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.create_file(buffer_pool_filename.c_str()));
+
+  DiskLogHandler log_handler;
+  DiskBufferPool *buffer_pool = nullptr;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+
+  BufferPoolLogReplayer log_replayer(buffer_pool_manager);
+  
+  ASSERT_EQ(RC::SUCCESS, log_handler.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler.replay(log_replayer, 0));
+  ASSERT_EQ(RC::SUCCESS, log_handler.start());
+
+  const int allocate_page_num = 100;
+  for (int i = 0; i < allocate_page_num; i++) {
+    Frame *frame = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+  }
+
+  const int allocate_page_num2 = 100;
+  const int deallocate_page_num = 50;
+  for (int i = 1; i <= allocate_page_num2 + deallocate_page_num; i++) {
+    if (i % 3 != 0) {
+      Frame *frame = nullptr;
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+    } else {
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->dispose_page(i / 3));
+    }
+  }
+  ASSERT_EQ(RC::SUCCESS, log_handler.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler.wait());
+
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(buffer_pool_filename.c_str()));
+  buffer_pool = nullptr;
+
+  /// 由于上次是正常关闭，那重新打开后，及时不重做日志，也不会有问题
+  /// 这里相当于测试正常关闭的状态下，再重做日志，是否会有问题
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+
+  DiskLogHandler log_handler2;
+  ASSERT_EQ(RC::SUCCESS, log_handler2.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler2.replay(log_replayer, 0));
+  ASSERT_EQ(allocate_page_num + allocate_page_num2 - deallocate_page_num, buffer_pool_page_count(buffer_pool));
+  ASSERT_EQ(RC::SUCCESS, log_handler2.start());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.wait());
+}
+
+TEST(BufferPoolLog, test_wal_exception)
+{
+  /// 测试没有落盘但是日志落盘的情况重做日志
+  /*
+    * 1. 创建一个buffer pool
+    * 2. 分配100个页面
+    * 3. 分配100个页面，释放50个页面
+    * 4. 关闭buffer pool并删除文件
+    * 5. 创建一个新文件，模拟日志没有落地的情况
+    * 6. 重做日志
+    * 7. 重做后的页面数应该是150
+  */
+  filesystem::path test_path("test_disk_buffer_pool_wal_exception");
+  filesystem::path clog_path = test_path / "clog";
+
+  filesystem::remove_all(test_path);
+  filesystem::create_directory(test_path);
+
+  filesystem::path buffer_pool_filename = test_path / "buffer_pool.bp";
+  BufferPoolManager buffer_pool_manager;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.create_file(buffer_pool_filename.c_str()));
+
+  BufferPoolLogReplayer log_replayer(buffer_pool_manager);
+
+  DiskLogHandler log_handler;
+  DiskBufferPool *buffer_pool = nullptr;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+
+  ASSERT_EQ(RC::SUCCESS, log_handler.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler.replay(log_replayer, 0));
+  ASSERT_EQ(RC::SUCCESS, log_handler.start());
+
+  const int allocate_page_num = 100;
+  for (int i = 0; i < allocate_page_num; i++) {
+    Frame *frame = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+  }
+
+  const int allocate_page_num2 = 100;
+  const int deallocate_page_num = 50;
+  for (int i = 1; i <= allocate_page_num2 + deallocate_page_num; i++) {
+    if (i % 3 != 0) {
+      Frame *frame = nullptr;
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+    } else {
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->dispose_page(i / 3));
+    }
+  }
+  ASSERT_EQ(RC::SUCCESS, log_handler.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler.wait());
+
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(buffer_pool_filename.c_str()));
+  buffer_pool = nullptr;
+
+  ASSERT_TRUE(filesystem::remove(buffer_pool_filename));
+
+  BufferPoolManager buffer_pool_manager2;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager2.create_file(buffer_pool_filename.c_str()));
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager2.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+
+  BufferPoolLogReplayer log_replayer2(buffer_pool_manager2);
+
+  DiskLogHandler log_handler2;
+  ASSERT_EQ(RC::SUCCESS, log_handler2.init(clog_path.c_str()));
+  LOG_INFO("replay log");
+  ASSERT_EQ(RC::SUCCESS, log_handler2.replay(log_replayer2, 0));
+  ASSERT_EQ(allocate_page_num + allocate_page_num2 - deallocate_page_num, buffer_pool_page_count(buffer_pool));
+  ASSERT_EQ(RC::SUCCESS, log_handler2.start());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.wait());
+}
+
+TEST(BufferPoolLog, test_wal_exception2)
+{
+  /// 测试没有落盘但是日志落盘的情况重做日志
+  /*
+    * 1. 创建一个buffer pool
+    * 2. 分配100个页面
+    * 3. 正常关闭文件
+    * 4. 复制文件保存起来
+    * 5. 重新打开日志和这个文件
+    * 6. 分配100个页面，释放50个页面
+    * 7. 关闭buffer pool并删除文件
+    * 8. 复制之前保存的文件
+    * 9. 打开复制的文件
+    * 10. 重做后的页面数应该是150
+  */
+  filesystem::path test_path("test_disk_buffer_pool_wal_exception");
+  filesystem::path clog_path = test_path / "clog";
+
+  filesystem::remove_all(test_path);
+  filesystem::create_directory(test_path);
+
+  filesystem::path buffer_pool_filename = test_path / "buffer_pool.bp";
+  BufferPoolManager buffer_pool_manager;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.create_file(buffer_pool_filename.c_str()));
+
+  BufferPoolLogReplayer log_replayer(buffer_pool_manager);
+  DiskBufferPool *buffer_pool = nullptr;
+  DiskLogHandler log_handler;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+
+  ASSERT_EQ(RC::SUCCESS, log_handler.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler.replay(log_replayer, 0));
+  ASSERT_EQ(RC::SUCCESS, log_handler.start());
+
+  /// step 2,3 创建100个页面然后正常关闭，包括关闭日志
+  const int allocate_page_num = 100;
+  for (int i = 0; i < allocate_page_num; i++) {
+    Frame *frame = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+  }
+
+  ASSERT_EQ(RC::SUCCESS, log_handler.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler.wait());
+
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(buffer_pool_filename.c_str()));
+  buffer_pool = nullptr;
+
+  /// step 4 备份文件
+  filesystem::path buffer_pool_filename_backup = test_path / "buffer_pool_backup.bp";
+  ASSERT_TRUE(filesystem::copy_file(buffer_pool_filename, buffer_pool_filename_backup));
+
+  /// step 5 重新打开日志和文件
+  DiskLogHandler log_handler2;
+  
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler2, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+  ASSERT_EQ(buffer_pool_page_count(buffer_pool), allocate_page_num);
+  ASSERT_EQ(RC::SUCCESS, log_handler2.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler2.replay(log_replayer, 0));
+  ASSERT_EQ(buffer_pool_page_count(buffer_pool), allocate_page_num);
+  ASSERT_EQ(RC::SUCCESS, log_handler2.start());
+
+  /// step 6 分配100个页面，释放50个页面
+  const int allocate_page_num2 = 100;
+  const int deallocate_page_num = 50;
+  for (int i = 1; i <= allocate_page_num2 + deallocate_page_num; i++) {
+    if (i % 3 != 0) {
+      Frame *frame = nullptr;
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+    } else {
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->dispose_page(i / 3));
+    }
+  }
+  ASSERT_EQ(RC::SUCCESS, log_handler2.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.wait());
+
+  ASSERT_EQ(allocate_page_num + allocate_page_num2 - deallocate_page_num, buffer_pool_page_count(buffer_pool));
+
+  /// step 7 关闭旧文件并删除他
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(buffer_pool_filename.c_str()));
+  buffer_pool = nullptr;
+  ASSERT_TRUE(filesystem::remove(buffer_pool_filename));
+
+  /// step 8 复制备份的文件
+  ASSERT_TRUE(filesystem::copy_file(buffer_pool_filename_backup, buffer_pool_filename));
+
+  /// step 9 打开复制后的文件，当前的文件页面数应该是100
+  DiskLogHandler log_handler3;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler3, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+
+  /// step 10 重做日志，应该有150个页面
+  ASSERT_EQ(RC::SUCCESS, log_handler3.init(clog_path.c_str()));
+  LOG_INFO("before the log handler 3 replay");
+  ASSERT_EQ(RC::SUCCESS, log_handler3.replay(log_replayer, 0));
+  ASSERT_EQ(allocate_page_num + allocate_page_num2 - deallocate_page_num, buffer_pool_page_count(buffer_pool));
+  ASSERT_EQ(RC::SUCCESS, log_handler3.start());
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(buffer_pool_filename.c_str()));
+  buffer_pool = nullptr;
+  ASSERT_EQ(RC::SUCCESS, log_handler3.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler3.wait());
+}
+
+TEST(BufferPoolLog, test_wal_multi_files)
+{
+  /// 测试多个buffer pool文件，没有正常落盘但是日志落地的情况。使用重建文件的方式模拟异常情况
+  /*
+    * 1. 创建10个buffer pool文件
+    * 2. 每个文件分配100个页面
+    * 3. 每个分配100个页面，释放50个页面
+    * 4. 关闭所有buffer pool文件并删除
+    * 5. 创建10个新文件，模拟日志没有落地的情况
+    * 6. 重做日志
+    * 7. 重做后每个文件页面数应该是150
+  */
+  filesystem::path test_path("test_disk_buffer_pool_wal_exception");
+  filesystem::path clog_path = test_path / "clog";
+
+  filesystem::remove_all(test_path);
+  filesystem::create_directory(test_path);
+
+  vector<filesystem::path> buffer_pool_filenames;
+  const int buffer_pool_file_num = 10;
+  for (int i = 0; i < buffer_pool_file_num; i++) {
+    filesystem::path buffer_pool_filename = test_path / ("buffer_pool_" + to_string(i) + ".bp");
+    buffer_pool_filenames.push_back(buffer_pool_filename);
+  }
+
+  BufferPoolManager buffer_pool_manager;
+  ranges::for_each(buffer_pool_filenames, [&buffer_pool_manager](const filesystem::path &filename) {
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.create_file(filename.c_str()));
+  });
+
+  DiskLogHandler log_handler;
+
+  vector<DiskBufferPool *> buffer_pools;
+  ranges::for_each(buffer_pool_filenames, 
+                   [&buffer_pool_manager, &buffer_pools, &log_handler](const filesystem::path &filename) {
+    DiskBufferPool *buffer_pool = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, filename.c_str(), buffer_pool));
+    buffer_pools.push_back(buffer_pool);
+  });
+
+  BufferPoolLogReplayer log_replayer(buffer_pool_manager);
+
+  ASSERT_EQ(RC::SUCCESS, log_handler.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler.replay(log_replayer, 0));
+  ASSERT_EQ(RC::SUCCESS, log_handler.start());
+
+  const int allocate_page_num = 100;
+  for (int i = 0; i < allocate_page_num; i++) {
+    ranges::for_each(buffer_pools, [](DiskBufferPool *buffer_pool) {
+      Frame *frame = nullptr;
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+    });
+  }
+
+  const int allocate_page_num2 = 100;
+  const int deallocate_page_num = 50;
+  for (int i = 1; i <= allocate_page_num2 + deallocate_page_num; i++) {
+    if (i % 3 != 0) {
+      ranges::for_each(buffer_pools, [](DiskBufferPool *buffer_pool) {
+        Frame *frame = nullptr;
+        ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+        ASSERT_EQ(RC::SUCCESS, buffer_pool->unpin_page(frame));
+      });
+    } else {
+      ranges::for_each(buffer_pools, [i](DiskBufferPool *buffer_pool) {
+        ASSERT_EQ(RC::SUCCESS, buffer_pool->dispose_page(i / 3));
+      });
+    }
+  }
+  ASSERT_EQ(RC::SUCCESS, log_handler.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler.wait());
+
+  ranges::for_each(buffer_pool_filenames, [&buffer_pool_manager](const filesystem::path &filename) {
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.close_file(filename.c_str()));
+  });
+  buffer_pools.clear();
+
+  ranges::for_each(buffer_pool_filenames, [](const filesystem::path &filename) {
+    ASSERT_TRUE(filesystem::remove(filename));
+  });
+
+  BufferPoolManager buffer_pool_manager2;
+  ranges::for_each(buffer_pool_filenames, [&buffer_pool_manager2](const filesystem::path &filename) {
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager2.create_file(filename.c_str()));
+  });
+
+  DiskLogHandler log_handler2;
+  ranges::for_each(buffer_pool_filenames, 
+                   [&buffer_pool_manager2, &buffer_pools, &log_handler2](const filesystem::path &filename) {
+    DiskBufferPool *buffer_pool = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager2.open_file(log_handler2, filename.c_str(), buffer_pool));
+    ASSERT_NE(buffer_pool, nullptr);
+    buffer_pools.push_back(buffer_pool);
+  });
+
+  BufferPoolLogReplayer log_replayer2(buffer_pool_manager2);
+  ASSERT_EQ(RC::SUCCESS, log_handler2.init(clog_path.c_str()));
+  ASSERT_EQ(RC::SUCCESS, log_handler2.replay(log_replayer2, 0));
+  ranges::for_each(buffer_pools, [](DiskBufferPool *buffer_pool) {
+    ASSERT_EQ(allocate_page_num + allocate_page_num2 - deallocate_page_num, buffer_pool_page_count(buffer_pool));
+  });
+  ASSERT_EQ(RC::SUCCESS, log_handler2.start());
+  ranges::for_each(buffer_pool_filenames, [&buffer_pool_manager2](const filesystem::path &filename) {
+    ASSERT_EQ(RC::SUCCESS, buffer_pool_manager2.close_file(filename.c_str()));
+  });
+  buffer_pools.clear();
+  ASSERT_EQ(RC::SUCCESS, log_handler2.stop());
+  ASSERT_EQ(RC::SUCCESS, log_handler2.wait());
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  filesystem::path log_filename = filesystem::path(argv[0]).filename();
+  LoggerFactory::init_default(log_filename.string() + ".log", LOG_LEVEL_TRACE);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/disk_buffer_pool_test.cpp
+++ b/unittest/disk_buffer_pool_test.cpp
@@ -1,0 +1,111 @@
+/* Copyright (c) 2021-2022 OceanBase and/or its affiliates. All rights reserved.
+miniob is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details. */
+
+//
+// Created by wangyunlai on 2024/02/01
+//
+
+#include "gtest/gtest.h"
+#include "common/log/log.h"
+#include "storage/buffer/disk_buffer_pool.h"
+#include "storage/clog/vacuous_log_handler.h"
+
+using namespace std;
+using namespace common;
+
+int buffer_pool_page_count(DiskBufferPool *buffer_pool)
+{
+  int count = 0;
+  BufferPoolIterator iterator;
+  iterator.init(*buffer_pool, 1);
+  while (iterator.has_next()) {
+    iterator.next();
+    count++;
+  }
+  return count;
+}
+
+TEST(DiskBufferPool, allocate_dispose)
+{
+  /*
+  1. 创建buffer pool manager
+  2. 创建buffer pool log handler
+  3. 创建disk buffer pool
+  4. 分配100个页面
+  5. 分配100个页面并释放50个页面
+  6. 统计buffer pool的总页面
+  7. 重启一下检查页面总个数
+  */
+
+  filesystem::path directory("buffer_pool");
+  filesystem::remove_all(directory);
+  filesystem::create_directories(directory);
+
+  filesystem::path buffer_pool_filename = directory / "buffer_pool.bp";
+
+  // 1. 创建buffer pool manager
+  BufferPoolManager buffer_pool_manager;
+
+  // 2. 创建buffer pool log handler
+  VacuousLogHandler log_handler;
+
+  // 3. 创建disk buffer pool
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.create_file(buffer_pool_filename.c_str()));
+  DiskBufferPool *buffer_pool = nullptr;
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+
+  // 4. 分配100个页面
+  const int allocate_page_num = 100;
+  for (int i = 0; i < allocate_page_num; ++i)
+  {
+    Frame *frame = nullptr;
+    ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+    ASSERT_NE(frame, nullptr);
+    ASSERT_EQ(buffer_pool->unpin_page(frame), RC::SUCCESS);
+    LOG_INFO("allocate one page");
+  }
+
+  // 5. 分配100个页面并释放50个页面
+  const int allocate_page_num2 = 100;
+  const int deallocate_page_num = 50;
+  for (int i = 1; i <= allocate_page_num2 + deallocate_page_num; i++) {
+    if (i % 3 == 0) {
+      ASSERT_EQ(buffer_pool->dispose_page(i / 3), RC::SUCCESS);
+      LOG_INFO("dispose one page");
+    } else {
+      Frame *frame = nullptr;
+      ASSERT_EQ(RC::SUCCESS, buffer_pool->allocate_page(&frame));
+      ASSERT_NE(frame, nullptr);
+      ASSERT_EQ(buffer_pool->unpin_page(frame), RC::SUCCESS);
+      LOG_INFO("allocate one page");
+    }
+  }
+
+  // 6. 统计buffer pool的总页面
+  ASSERT_EQ(buffer_pool_page_count(buffer_pool), allocate_page_num + allocate_page_num2 - deallocate_page_num);
+
+  // 7. 重启一下检查页面总个数
+  ASSERT_EQ(buffer_pool_manager.close_file(buffer_pool_filename.c_str()), RC::SUCCESS);
+
+  ASSERT_EQ(RC::SUCCESS, buffer_pool_manager.open_file(log_handler, buffer_pool_filename.c_str(), buffer_pool));
+  ASSERT_NE(buffer_pool, nullptr);
+  ASSERT_EQ(buffer_pool_page_count(buffer_pool), allocate_page_num + allocate_page_num2 - deallocate_page_num);
+
+  ASSERT_EQ(buffer_pool_manager.close_file(buffer_pool_filename.c_str()), RC::SUCCESS);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  filesystem::path log_filename = filesystem::path(argv[0]).filename();
+  LoggerFactory::init_default(log_filename.string() + ".log", LOG_LEVEL_TRACE);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/disk_log_handler_test.cpp
+++ b/unittest/disk_log_handler_test.cpp
@@ -16,7 +16,7 @@ See the Mulan PSL v2 for more details. */
 #define protected public
 
 #include "gtest/gtest.h"
-#include "storage/clog/log_handler.h"
+#include "storage/clog/disk_log_handler.h"
 #include "storage/clog/log_replayer.h"
 #include "common/thread/thread_pool_executor.h"
 
@@ -39,11 +39,11 @@ private:
   int64_t count_ = 0;
 };
 
-TEST(LogHandler, empty)
+TEST(DiskLogHandler, empty)
 {
-  // specific an empty directory and test LogHandler start/stop and so on
+  // specific an empty directory and test DiskLogHandler start/stop and so on
   const char *path = "test_log_handler";
-  LogHandler handler;
+  DiskLogHandler handler;
   ASSERT_EQ(RC::SUCCESS, handler.init(path));
   ASSERT_EQ(RC::SUCCESS, handler.start());
   ASSERT_EQ(RC::SUCCESS, handler.stop());
@@ -52,13 +52,13 @@ TEST(LogHandler, empty)
   filesystem::remove_all(path);
 }
 
-TEST(LogHandler, test_append_and_wait)
+TEST(DiskLogHandler, test_append_and_wait)
 {
-  // specific an empty directory and call LogHandler::append 10000 times and stop it
+  // specific an empty directory and call DiskLogHandler::append 10000 times and stop it
   const char *path = "test_log_handler";
   filesystem::remove_all(path);
 
-  LogHandler handler;
+  DiskLogHandler handler;
   ASSERT_EQ(RC::SUCCESS, handler.init(path));
   TestLogReplayer replayer;
   ASSERT_EQ(RC::SUCCESS, handler.replay(replayer, 0));
@@ -80,14 +80,14 @@ TEST(LogHandler, test_append_and_wait)
   filesystem::remove_all(path);
 }
 
-TEST(LogHandler, test_replay)
+TEST(DiskLogHandler, test_replay)
 {
-  // create an empty directory and init a LogHandler and then test replay
+  // create an empty directory and init a DiskLogHandler and then test replay
   // We will do nothing as there is no log file in the directory
   const char *path = "test_log_handler";
   filesystem::remove_all(path);
 
-  LogHandler handler;
+  DiskLogHandler handler;
   TestLogReplayer replayer;
   ASSERT_EQ(RC::SUCCESS, handler.init(path));
   ASSERT_EQ(RC::SUCCESS, handler.replay(replayer, 0));
@@ -114,7 +114,7 @@ TEST(LogHandler, test_replay)
 
   LOG_INFO("write %d log entries done and restart log handle", times);
 
-  LogHandler handler2;
+  DiskLogHandler handler2;
   ASSERT_EQ(RC::SUCCESS, handler2.init(path));
   ASSERT_EQ(RC::SUCCESS, handler2.replay(replayer, 0));
   ASSERT_EQ(times, replayer.count());
@@ -137,7 +137,7 @@ TEST(LogHandler, test_replay)
   ASSERT_EQ(RC::SUCCESS, handler2.iterate(log_entry_counter, 0));
   ASSERT_EQ(count, times + times2);
 
-  LogHandler handler3;
+  DiskLogHandler handler3;
   ASSERT_EQ(RC::SUCCESS, handler3.init(path));
   TestLogReplayer replayer3;
   ASSERT_EQ(RC::SUCCESS, handler3.replay(replayer3, 2000));
@@ -147,12 +147,12 @@ TEST(LogHandler, test_replay)
   // filesystem::remove_all(path);
 }
 
-TEST(LogHandler, multi_thread)
+TEST(DiskLogHandler, multi_thread)
 {
   const char *directory = "test_log_handler_multi_thread";
   filesystem::remove_all(directory);
 
-  LogHandler handler;
+  DiskLogHandler handler;
   TestLogReplayer replayer;
   ASSERT_EQ(RC::SUCCESS, handler.init(directory));
   ASSERT_EQ(RC::SUCCESS, handler.replay(replayer, 0));
@@ -160,7 +160,7 @@ TEST(LogHandler, multi_thread)
 
   const int times = 200000;
   ThreadPoolExecutor executor;
-  ASSERT_EQ(0, executor.init("TestLogHandler", 4, 4, 60*1000));
+  ASSERT_EQ(0, executor.init("TestDiskLogHandler", 4, 4, 60*1000));
 
   for (int i = 0; i < times; ++i) {
     ASSERT_EQ(0, executor.execute([&handler]() -> void {

--- a/unittest/record_manager_test.cpp
+++ b/unittest/record_manager_test.cpp
@@ -18,12 +18,15 @@ See the Mulan PSL v2 for more details. */
 #include "storage/buffer/disk_buffer_pool.h"
 #include "storage/record/record_manager.h"
 #include "storage/trx/vacuous_trx.h"
+#include "storage/clog/vacuous_log_handler.h"
 #include "gtest/gtest.h"
 
 using namespace common;
 
 TEST(test_record_page_handler, test_record_page_handler)
 {
+  VacuousLogHandler log_handler;
+
   const char *record_manager_file = "record_manager.bp";
   ::remove(record_manager_file);
 
@@ -32,7 +35,7 @@ TEST(test_record_page_handler, test_record_page_handler)
   RC                 rc  = bpm->create_file(record_manager_file);
   ASSERT_EQ(rc, RC::SUCCESS);
 
-  rc = bpm->open_file(record_manager_file, bp);
+  rc = bpm->open_file(log_handler, record_manager_file, bp);
   ASSERT_EQ(rc, RC::SUCCESS);
 
   Frame *frame = nullptr;
@@ -111,6 +114,8 @@ TEST(test_record_page_handler, test_record_page_handler)
 
 TEST(test_record_page_handler, test_record_file_iterator)
 {
+  VacuousLogHandler log_handler;
+
   const char *record_manager_file = "record_manager.bp";
   ::remove(record_manager_file);
 
@@ -119,7 +124,7 @@ TEST(test_record_page_handler, test_record_file_iterator)
   RC                 rc  = bpm->create_file(record_manager_file);
   ASSERT_EQ(rc, RC::SUCCESS);
 
-  rc = bpm->open_file(record_manager_file, bp);
+  rc = bpm->open_file(log_handler, record_manager_file, bp);
   ASSERT_EQ(rc, RC::SUCCESS);
 
   RecordFileHandler file_handler;


### PR DESCRIPTION
### What problem were solved in this pull request?

Problem:
实现 buffer pool 支持WAL

### What is changed and how it works?
buffer pool中分配和释放页面时，记录日志，并支持日志恢复。
当前buffer pool不会从文件中删除某个页面，释放是指标记为未删除。

- 在分配释放页面记录日志时，并没有等待日志完成；
- 将页面数据刷新到磁盘中时，会等待对应的日志刷新到磁盘

### Other information
1. 日志接口LogHandler转换为纯接口，并实现DiskLogHandler表示记录磁盘的日志处理器，与VacuousLogHandler，表示一个什么都不做的日志处理器，用于测试；
2. 一个LogHandler属于一个Db，Db中使用 DiskLogHandler；
3. 在创建表、索引时，需要想办法传递 LogHandler；
4. BufferPoolManager 仍为全局对象，不是Db专属的。
